### PR TITLE
[Op] cuDNN RNN Symbol

### DIFF
--- a/src/operator/cudnn_rnn-inl.h
+++ b/src/operator/cudnn_rnn-inl.h
@@ -7,9 +7,12 @@
 #ifndef MXNET_OPERATOR_CUDNN_RNN_INL_H_
 #define MXNET_OPERATOR_CUDNN_RNN_INL_H_
 
-#include <algorithm>
 #include <vector>
+#include <map>
+#include <string>
+#include <utility>
 #include "./rnn-inl.h"
+
 namespace mxnet {
 namespace op {
 #if defined(__CUDACC__) && MXNET_USE_CUDNN == 1 && CUDNN_MAJOR == 5

--- a/src/operator/cudnn_rnn-inl.h
+++ b/src/operator/cudnn_rnn-inl.h
@@ -1,0 +1,208 @@
+/*!
+ * Copyright (c) 2016 by Contributors
+ * \file cudnn_spatial_transformer-inl.h
+ * \brief
+ * \author Sebastian Bodenstein
+*/
+#ifndef MXNET_OPERATOR_CUDNN_RNN_INL_H_
+#define MXNET_OPERATOR_CUDNN_RNN_INL_H_
+
+#include <algorithm>
+#include <vector>
+#include "./rnn-inl.h"
+namespace mxnet {
+namespace op {
+#if defined(__CUDACC__) && MXNET_USE_CUDNN == 1 && CUDNN_MAJOR == 5
+template<typename DType>
+class CuDNNRNNOp : public Operator {
+ public:
+  explicit CuDNNRNNOp(RNNParam param) {
+    this->param_ = param;
+    init_cudnn_ = false;
+    dtype_ = mshadow::DataType<DType>::kCudnnFlag;
+    // RNN Mode
+    switch (param_.mode) {
+      case rnn_enum::kRnnRelu:
+        rnn_mode_ = CUDNN_RNN_RELU;
+        break;
+      case rnn_enum::kRnnTanh:
+        rnn_mode_ = CUDNN_RNN_TANH;
+        break;
+      case rnn_enum::kLstm:
+        rnn_mode_ = CUDNN_LSTM;
+        break;
+      case rnn_enum::kGru:
+        rnn_mode_ = CUDNN_GRU;
+        break;
+      default:
+        LOG(FATAL) << "Not implmented";
+    }
+    // RNN Direction
+    switch (param_.direction) {
+      case rnn_enum::kUnidirectional:
+        rnn_direction_ = CUDNN_UNIDIRECTIONAL;
+        break;
+      case rnn_enum::kBidirectional:
+        rnn_direction_ = CUDNN_BIDIRECTIONAL;
+        break;
+      default:
+        LOG(FATAL) << "Not implmented";
+    }
+  }
+  // ~CuDNNRNNOp() {
+  //   if (init_cudnn_) {
+  //     CHECK_EQ(cudnnDestroyRNNDescriptor(rnn_desc_), CUDNN_STATUS_SUCCESS);
+  //     // CHECK_EQ(cudnnDestroyTensorDescriptor(rnn_desc_), CUDNN_STATUS_SUCCESS);
+  //     // CHECK_EQ(cudnnDestroyTensorDescriptor(_desc_), CUDNN_STATUS_SUCCESS);
+  //   }
+  // }
+ 
+  virtual void Forward(const OpContext &ctx,
+                       const std::vector<TBlob> &in_data,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &out_data,
+                       const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+ //    CHECK_EQ(in_data.size(), 2);
+ //    CHECK_EQ(out_data.size(), 3);
+ //    Stream<gpu> *s = ctx.get_stream<gpu>();
+ //    Tensor<gpu, 4, DType> data = in_data[st::kData].get<gpu, 4, DType>(s);
+ //    Tensor<gpu, 4, DType> out = out_data[st::kOut].get<gpu, 4, DType>(s);
+ //    Shape<3> loc_shape = Shape3(data.size(0), 2, 3);
+ //    Shape<4> grid_shape = Shape4(out.size(0), out.size(2), out.size(3), 2);
+ //    Tensor<gpu, 3, DType> loc = in_data[st::kLoc].get_with_shape<gpu, 3, DType>(loc_shape, s);
+ //    Tensor<gpu, 4, DType> grid = out_data[st::kGridSrc]
+ //                                .get_with_shape<gpu, 4, DType>(grid_shape, s);
+ //    if (!init_cudnn_) {
+ //     Init(s, in_data, out_data);
+ //    }
+ //    CHECK_EQ(data.CheckContiguous(), true);
+ //    CHECK_EQ(out.CheckContiguous(), true);
+ //    typename DataType<DType>::ScaleType alpha = 1.0f;
+ //    typename DataType<DType>::ScaleType beta = 0.0f;
+ //    if (param_.transform_type == st::kAffine) {
+ //      CHECK_EQ(cudnnSpatialTfGridGeneratorForward(s->dnn_handle_,
+ //                                                  st_desc_,
+ //                                                  loc.dptr_,
+ //                                                  grid.dptr_/*output*/), CUDNN_STATUS_SUCCESS);
+ //    }
+ //    CHECK_EQ(cudnnSpatialTfSamplerForward(s->dnn_handle_,
+ //                                          st_desc_,
+ //                                          &alpha,
+ //                                          in_desc_,
+ //                                          data.dptr_,
+ //                                          grid.dptr_,
+ //                                          &beta,
+ //                                          out_desc_,
+ //                                          out.dptr_/*output*/), CUDNN_STATUS_SUCCESS);
+  }
+ //
+  virtual void Backward(const OpContext &ctx,
+                        const std::vector<TBlob> &out_grad,
+                        const std::vector<TBlob> &in_data,
+                        const std::vector<TBlob> &out_data,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<TBlob> &in_grad,
+                        const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+ //    CHECK_EQ(in_data.size(), 2);
+ //    CHECK_EQ(out_data.size(), 3);
+ //    CHECK_EQ(out_grad.size(), 1);
+ //    Stream<gpu> *s = ctx.get_stream<gpu>();
+ //    Tensor<gpu, 4, DType> data = in_data[st::kData].get<gpu, 4, DType>(s);
+ //    Tensor<gpu, 4, DType> grad = out_grad[st::kOut].get<gpu, 4, DType>(s);
+ //    Tensor<gpu, 4, DType> ddata = in_grad[st::kData].get<gpu, 4, DType>(s);
+ //    Shape<3> loc_shape = Shape3(data.size(0), 2, 3);
+ //    Shape<4> grid_shape = Shape4(grad.size(0), grad.size(2), grad.size(3), 2);
+ //    Tensor<gpu, 3, DType> dloc = in_grad[st::kLoc].get_with_shape<gpu, 3, DType>(loc_shape, s);
+ //    Tensor<gpu, 4, DType> grid = out_data[st::kGridSrc]
+ //                    .get_with_shape<gpu, 4, DType>(grid_shape, s);
+ //    // do not use out_grad[st::kGridSrc], because dgrid is a intermediate tensor, and not include in
+ //    // DeclareBackwardDependency, another, we can we reuse grid for inplace operator
+ //    typename DataType<DType>::ScaleType alpha = 1.0f;
+ //    typename DataType<DType>::ScaleType beta = 0.0f;
+ //    typename DataType<DType>::ScaleType alpha_dgrid = 1.0f;
+ //    typename DataType<DType>::ScaleType beta_dgrid = 0.0f;
+ //    CHECK_EQ(cudnnSpatialTfSamplerBackward(s->dnn_handle_,
+ //                                           st_desc_,
+ //                                           &alpha,
+ //                                           in_desc_,
+ //                                           data.dptr_,
+ //                                           &beta,
+ //                                           in_desc_/*reuse in_desc_*/,
+ //                                           ddata.dptr_/*output*/,
+ //                                           &alpha_dgrid,
+ //                                           out_desc_/*reuse out_desc_*/,
+ //                                           grad.dptr_,
+ //                                           grid.dptr_,
+ //                                           &beta_dgrid,
+ //                                           grid.dptr_/*output, reuse grid*/), CUDNN_STATUS_SUCCESS);
+ //    if (param_.transform_type == st::kAffine) {
+ //      CHECK_EQ(cudnnSpatialTfGridGeneratorBackward(s->dnn_handle_,
+ //                                                   st_desc_,
+ //                                                   grid.dptr_,
+ //                                                   dloc.dptr_/*out*/), CUDNN_STATUS_SUCCESS);
+ //    }
+  }
+ //
+ private:
+  inline void Init(mshadow::Stream<gpu> *s,
+                   const std::vector<TBlob> &in_data,
+                   const std::vector<TBlob> &out_data) {
+    using namespace mshadow;
+    // CHECK_EQ(in_data.size(), 2);
+    // CHECK_EQ(out_data.size(), 3);
+    // if (!init_cudnn_) {
+    //   init_cudnn_ = true;
+    //   // Tensor<gpu, 4, DType> data = in_data[st::kData].get<gpu, 4, DType>(s);
+    //   // Tensor<gpu, 4, DType> out = out_data[st::kOut].get<gpu, 4, DType>(s);
+    //   CHECK_EQ(cudnnCreateRNNDescriptor(&rnn_desc_), CUDNN_STATUS_SUCCESS);
+    //   CHECK_EQ(cudnnCreateDropoutDescriptor(&rnn_dropout_), CUDNN_STATUS_SUCCESS);
+
+    //   CHECK_EQ(cudnnCreateTensorDescriptor(&in_desc_), CUDNN_STATUS_SUCCESS);
+    //   CHECK_EQ(cudnnCreateTensorDescriptor(&out_desc_), CUDNN_STATUS_SUCCESS);
+    //   CHECK_EQ(cudnnSetTensor4dDescriptor(in_desc_,
+    //                                       format_,
+    //                                       dtype_,
+    //                                       data.size(0),
+    //                                       data.size(1),
+    //                                       data.size(2),
+    //                                       data.size(3)), CUDNN_STATUS_SUCCESS);
+    //   CHECK_EQ(cudnnSetTensor4dDescriptor(out_desc_,
+    //                                       format_,
+    //                                       dtype_,
+    //                                       out.size(0),
+    //                                       out.size(1),
+    //                                       out.size(2),
+    //                                       out.size(3)), CUDNN_STATUS_SUCCESS);
+    //   if (param_.sampler_type == st::kBilinear) {
+    //     int dim[] = {static_cast<int>(out.size(0)), static_cast<int>(out.size(1)),
+    //                  static_cast<int>(out.size(2)), static_cast<int>(out.size(3))};
+    //     CHECK_EQ(cudnnSetSpatialTransformerNdDescriptor(st_desc_,
+    //                                                     sampler_,
+    //                                                     dtype_,
+    //                                                     4,
+    //                                                     dim) , CUDNN_STATUS_SUCCESS);
+    //   }
+    // }
+  }
+ 
+  bool init_cudnn_;
+  cudnnDataType_t dtype_;
+  cudnnRNNDescriptor_t rnn_desc_;
+  cudnnRNNMode_t rnn_mode_;
+  cudnnDirectionMode_t rnn_direction_;
+  cudnnRNNInputMode_t rnn_input_mode_;
+  cudnnDropoutDescriptor_t rnn_dropout_;
+  // cudnnTensorDescriptor_t in_desc_;
+  // cudnnTensorDescriptor_t out_desc_;
+  #if CUDNN_MAJOR == 5
+  cudnnTensorFormat_t format_;
+  #endif
+  RNNParam param_;
+};
+#endif  // __CUDACC__ && CUDNN
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_CUDNN_SPATIAL_TRANSFORMER_INL_H_

--- a/src/operator/cudnn_rnn-inl.h
+++ b/src/operator/cudnn_rnn-inl.h
@@ -314,7 +314,7 @@ class CuDNNRNNOp : public Operator {
                                   strideA
                                   ), CUDNN_STATUS_SUCCESS);
         dimA[0] = param_.batch_size_;                        
-        dimA[1] = param_.bidirectional ? param_.state_size_ * 2 : param_.state_size_;
+        dimA[1] = param_.bidirectional ? param_.state_size * 2 : param_.state_size;
         dimA[2] = 1;
         strideA[0] = dimA[2] * dimA[1];
         strideA[1] = dimA[2];
@@ -339,9 +339,9 @@ class CuDNNRNNOp : public Operator {
       dy_desc_vec_ = dy_vec;
 
       // set the state tensors                       
-      dimA[0] = param_.num_layers_ * (param_.bidirectional ? 2 : 1);
+      dimA[0] = param_.num_layers * (param_.bidirectional ? 2 : 1);
       dimA[1] = param_.batch_size_;
-      dimA[2] = param_.state_size_;
+      dimA[2] = param_.state_size;
       strideA[0] = dimA[2] * dimA[1];
       strideA[1] = dimA[2];
       strideA[2] = 1;
@@ -419,8 +419,8 @@ class CuDNNRNNOp : public Operator {
       // RNN descriptors       
       CHECK_EQ(cudnnCreateRNNDescriptor(&rnn_desc_), CUDNN_STATUS_SUCCESS);
       CHECK_EQ(cudnnSetRNNDescriptor(rnn_desc_,
-                                    param_.state_size_,
-                                    param_.num_layers_,
+                                    param_.state_size,
+                                    param_.num_layers,
                                     dropout_desc_,
                                     input_mode_,
                                     direction_,

--- a/src/operator/cudnn_rnn-inl.h
+++ b/src/operator/cudnn_rnn-inl.h
@@ -197,16 +197,16 @@ class CuDNNRNNOp : public Operator {
 
     // Deal with lstm
     void * dcx_ptr = NULL;
-    void * dcy_ptr = NULL;  
+    void * dcy_ptr = NULL;
     void * cx_ptr = NULL;
 
-    if(param_.mode == rnn_enum::kLstm) {
+    if (param_.mode == rnn_enum::kLstm) {
       cx_ptr = (in_data[rnn_enum::kStateCell].get<gpu, 3, DType>(s)).dptr_;
       dcx_ptr = (in_grad[rnn_enum::kStateCell].get<gpu, 3, DType>(s)).dptr_;
     }
     if ((param_.mode == rnn_enum::kLstm) && param_.state_outputs)
         dcy_ptr = (out_grad[rnn_enum::kStateCellOut].get<gpu, 3, DType>(s)).dptr_;
-    
+
     CHECK_EQ(x.CheckContiguous(), true);
     CHECK_EQ(w.CheckContiguous(), true);
     CHECK_EQ(hx.CheckContiguous(), true);

--- a/src/operator/cudnn_rnn-inl.h
+++ b/src/operator/cudnn_rnn-inl.h
@@ -41,6 +41,12 @@ class CuDNNRNNOp : public Operator {
     }
     // RNN Direction
     direction_ = param_.bidirectional ? CUDNN_BIDIRECTIONAL : CUDNN_UNIDIRECTIONAL;
+    // Other
+    param_.pkeep_ = 1.0f - param_.p;
+    if(param_.mode == rnn_enum::kLstm)
+      param_.lstm_q_ = true;
+    else
+      param_.lstm_q_ = false;
   }
 
   ~CuDNNRNNOp() {
@@ -212,7 +218,6 @@ class CuDNNRNNOp : public Operator {
     Tensor<gpu, 1, DType> temp_space =
       ctx.requested[rnn_enum::kTempSpace].get_space_typed<gpu, 1, DType>(
                               mshadow::Shape1(temp_size), s);
-    
     CHECK_EQ(cudnnRNNBackwardData(s->dnn_handle_,
                                 rnn_desc_,
                                 param_.seq_length_,

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -21,8 +21,8 @@ namespace mxnet {
 namespace op {
 
 namespace rnn_enum {
-  enum RNNOpInputs {kData, kParams, kStateIn, kCellStateIn};
-  enum RNNOpOutputs {kOut, kStateOut, kCellStateOut};
+  enum RNNOpInputs {kData, kParams, kState, kStateCell};
+  enum RNNOpOutputs {kOut, kStateOut, kStateCellOut};
   enum RNNModeType {kRnnRelu, kRnnTanh, kLstm, kGru};
   enum RNNOpResource {kTempSpace};
 }
@@ -195,11 +195,11 @@ class RNNProp : public OperatorProperty {
     int numDirections = param_.bidirectional ? 2 : 1;
     int total_layers = numDirections * param_.num_layers_; // double for bidirectional
     SHAPE_ASSIGN_CHECK(*in_shape,
-                       rnn_enum::kStateIn,
+                       rnn_enum::kState,
                        Shape3(total_layers, batch_size, param_.state_size_));
     if (param_.mode == rnn_enum::kLstm){
       SHAPE_ASSIGN_CHECK(*in_shape,
-                        rnn_enum::kCellStateIn,
+                        rnn_enum::kStateCell,
                         Shape3(total_layers, batch_size, param_.state_size_));
     }
     // calculate parameter vector length

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -74,6 +74,7 @@ struct RNNParam : public dmlc::Parameter<RNNParam> {
   bool batch_first;
   int direction;
   int mode;
+  float p;
 
   DMLC_DECLARE_PARAMETER(RNNParam) {
     DMLC_DECLARE_FIELD(state_size)
@@ -96,6 +97,10 @@ struct RNNParam : public dmlc::Parameter<RNNParam> {
     .add_enum("lstm", rnn_enum::kLstm)
     .add_enum("gru", rnn_enum::kGru)
     .describe("the type of RNN to compute");
+    
+    DMLC_DECLARE_FIELD(p).set_default(0.)
+    .set_range(0, 1)
+    .describe("Fraction of the input that gets dropped out at training time");
   }
 };
 

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -144,7 +144,7 @@ class RNNProp : public OperatorProperty {
  public:
   std::vector<std::string> ListArguments() const override {
     if (param_.mode == rnn_enum::kLstm) {
-      return {"data", "parameters", "state", "cell_state"};
+      return {"data", "parameters", "state", "state_cell"};
     } else {
       return {"data", "parameters", "state"};
     }
@@ -164,9 +164,9 @@ class RNNProp : public OperatorProperty {
       return 2;
   }
 
-  int NumVisibleOutputs() const override {
-    return 1;
-  }
+  // int NumVisibleOutputs() const override {
+  //   return 1;
+  // }
 
   void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
     param_.Init(kwargs);

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -264,10 +264,22 @@ class RNNProp : public OperatorProperty {
     const std::vector<int> &out_grad,
     const std::vector<int> &in_data,
     const std::vector<int> &out_data) const override {
-    if (param_.mode == rnn_enum::kLstm)
-      return {out_grad[rnn_enum::kOut], in_data[rnn_enum::kData], in_data[rnn_enum::kParams]};
-    else
-      return {out_grad[rnn_enum::kOut], in_data[rnn_enum::kData], in_data[rnn_enum::kParams]};
+    std::vector<int> dep = {in_data[rnn_enum::kData], in_data[rnn_enum::kParams],
+        in_data[rnn_enum::kState], out_data[rnn_enum::kOut], out_grad[rnn_enum::kOut]};
+
+    if (param_.state_outputs) {
+      dep.push_back(out_data[rnn_enum::kStateOut]);
+      dep.push_back(out_grad[rnn_enum::kStateOut]);
+    }
+
+    if (param_.mode == rnn_enum::kLstm) {
+      dep.push_back(in_data[rnn_enum::kStateCell]);
+      if(param_.state_outputs) {
+        dep.push_back(out_data[rnn_enum::kStateCellOut]);
+        dep.push_back(out_grad[rnn_enum::kStateCellOut]);
+      }
+    }
+    return dep;
   }
 
   std::vector<ResourceRequest> ForwardResource(

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -67,8 +67,8 @@ inline int rnn_param_size(int layerNum,
 }
 
 struct RNNParam : public dmlc::Parameter<RNNParam> {
-  uint32_t state_size_;
-  uint32_t num_layers_;
+  uint32_t state_size;
+  uint32_t num_layers;
   bool bidirectional;
   int mode;
   float p, pkeep_;
@@ -76,10 +76,10 @@ struct RNNParam : public dmlc::Parameter<RNNParam> {
   bool lstm_q_; // whether type is lstm 
 
   DMLC_DECLARE_PARAMETER(RNNParam) {
-    DMLC_DECLARE_FIELD(state_size_)
+    DMLC_DECLARE_FIELD(state_size)
     .describe("size of the state for each layer");
 
-    DMLC_DECLARE_FIELD(num_layers_)
+    DMLC_DECLARE_FIELD(num_layers)
     .describe("number of stacked layers");
 
     DMLC_DECLARE_FIELD(bidirectional).set_default(false)
@@ -193,29 +193,29 @@ class RNNProp : public OperatorProperty {
     int batch_size = dshape[1];
     int input_size = dshape[2];
     int numDirections = param_.bidirectional ? 2 : 1;
-    int total_layers = numDirections * param_.num_layers_; // double for bidirectional
+    int total_layers = numDirections * param_.num_layers; // double for bidirectional
     SHAPE_ASSIGN_CHECK(*in_shape,
                        rnn_enum::kState,
-                       Shape3(total_layers, batch_size, param_.state_size_));
+                       Shape3(total_layers, batch_size, param_.state_size));
     if (param_.mode == rnn_enum::kLstm){
       SHAPE_ASSIGN_CHECK(*in_shape,
                         rnn_enum::kStateCell,
-                        Shape3(total_layers, batch_size, param_.state_size_));
+                        Shape3(total_layers, batch_size, param_.state_size));
     }
     // calculate parameter vector length
-    int param_size = rnn_param_size(param_.num_layers_,
+    int param_size = rnn_param_size(param_.num_layers,
                                     input_size,
-                                    param_.state_size_,
+                                    param_.state_size,
                                     param_.bidirectional,
                                     param_.mode);
     SHAPE_ASSIGN_CHECK(*in_shape, rnn_enum::kParams, Shape1(param_size));
     // output: [sequence len, batch, output size]
     TShape oshape = dshape;
-    oshape[2] = numDirections * param_.state_size_;
+    oshape[2] = numDirections * param_.state_size;
     TShape outStateShape = dshape;
     outStateShape[0] = total_layers;
     outStateShape[1] = batch_size;
-    outStateShape[2] = param_.state_size_;
+    outStateShape[2] = param_.state_size;
 
     out_shape->clear();
     out_shape->push_back(oshape);

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -29,7 +29,6 @@ namespace rnn_enum {
 }
 
 // A utility function to calculate input size
-
 inline int rnn_single_param_size(int inputSize,
                                 int hiddenSize, 
                                 int mode){
@@ -116,86 +115,7 @@ class RNNOp : public Operator {
                        const std::vector<TBlob> &aux_args) {
     using namespace mshadow;
     using namespace mshadow::expr;
-//     CHECK_EQ(req[rnn_enum::kOut], kWriteTo);
-  
-//     CHECK_EQ(in_data.size(), expected);
-//     CHECK_EQ(out_data.size(), 1);
-//     Stream<xpu> *s = ctx.get_stream<xpu>();
-//     Tensor<xpu, 4, DType> data = in_data[rnn_enum::kData].get<xpu, 4, DType>(s);
-//     Tensor<xpu, 4, DType> out = out_data[rnn_enum::kOut].get<xpu, 4, DType>(s);
-//     Shape<3> wmat_shape =
-//         Shape3(param_.num_group,
-//                data.shape_[1] / param_.num_group,
-//                param_.num_filter / param_.num_group * param_.kernel[0] * param_.kernel[1]);
-//     Tensor<xpu, 3, DType> wmat =
-//         in_data[rnn_enum::kWeight].get_with_shape<xpu, 3, DType>(wmat_shape, s);
-// #if defined(__CUDACC__)
-//     CHECK_EQ(s->blas_handle_ownership_, Stream<xpu>::OwnHandle)
-//         << "Must init CuBLAS handle in stream";
-// #endif
-//     const index_t nbatch = data.size(0);
-//     Tensor<xpu, 1, DType> workspace =
-//         ctx.requested[rnn_enum::kTempSpace].get_space_typed<xpu, 1, DType>(
-//             Shape1(this->InitTemp(out.shape_, data.shape_)), s);
-//     for (index_t i = 0; i < nbatch; i += nstep_) {
-//       const index_t step = std::min(nstep_, nbatch - i);
-//       Tensor<xpu, 2, DType> temp_col = Tensor<xpu, 2, DType>(
-//                                             workspace.dptr_,
-//                                             Shape2(shape_colunit_[0],
-//                                             shape_colunit_[1] * step), s);
-//       Tensor<xpu, 3, DType> temp_dst = Tensor<xpu, 3, DType>(
-//                                            workspace.dptr_ + temp_col.shape_.Size(),
-//                                            Shape3(shape_dstunit_[0],
-//                                            shape_dstunit_[1],
-//                                            shape_dstunit_[2] * step), s);
-//       temp_dst = reshape(swapaxis<1, 0>(data.Slice(i, i + step)), temp_dst.shape_);
-//       if (param_.pad[0] == 0 && param_.pad[1] == 0) {
-//         temp_col = unpack_patch2col(out.Slice(i, i + step),
-//                                     param_.kernel[0],
-//                                     param_.kernel[1],
-//                                     param_.stride[0],
-//                                     param_.stride[1],
-//                                     1, 1);  // RNN only support dilate equals 1
-//       } else {
-//         temp_col = unpack_patch2col(pad(out.Slice(i, i + step),
-//                                         param_.pad[0], param_.pad[1]),
-//                                     param_.kernel[0],
-//                                     param_.kernel[1],
-//                                     param_.stride[0],
-//                                     param_.stride[1],
-//                                     1, 1);  // RNN only support dilate equals 1
-//       }
-//       const index_t gstride = temp_col.size(0) / param_.num_group;
-//       for (uint32_t gid = 0; gid < param_.num_group; ++gid) {
-//         mshadow::Tensor<xpu, 2, DType> tmpc = temp_col.Slice(gstride * gid,
-//                                               gstride * (gid + 1));
-//         tmpc = dot(wmat[gid].T(), temp_dst[gid]);
-//       }
-//       if (param_.pad[0] == 0 && param_.pad[1] == 0) {
-//         out.Slice(i, i + step) = pack_col2patch(temp_col,
-//                                    out.Slice(i, i + step).shape_,
-//                                    param_.kernel[0],
-//                                    param_.kernel[1],
-//                                    param_.stride[0],
-//                                    1);  // RNN only support dilate equals 1
-//       } else {
-//         Shape<4> pshape = out.Slice(i, i + step).shape_;
-//         pshape[2] += 2 * param_.pad[0];
-//         pshape[3] += 2 * param_.pad[1];
-//         out.Slice(i, i + step) = crop(pack_col2patch(temp_col,
-//                                         pshape,
-//                                         param_.kernel[0],
-//                                         param_.kernel[1],
-//                                         param_.stride[0],
-//                                         1),  // RNN only support dilate equals 1
-//                                         out[i][0].shape_);
-//       }
-//     }
-//     if (!param_.no_bias) {
-//       // add bias, broadcast bias to dim 1: channel
-//       Tensor<xpu, 1, DType> bias = in_data[rnn_enum::kBias].get<xpu, 1, DType>(s);
-//       out += broadcast<1>(bias, out.shape_);
-//     }
+    // TODO: add MShadow implementation
   }
 
   virtual void Backward(const OpContext &ctx,
@@ -207,124 +127,12 @@ class RNNOp : public Operator {
                         const std::vector<TBlob> &aux_args) {
     using namespace mshadow;
     using namespace mshadow::expr;
-    // TODO(bing): check the BLAS Handle, be careful
-//     CHECK_EQ(out_grad.size(), 1);
-//     size_t expected = param_.no_bias == 0 ? 3 : 2;
-//     CHECK(in_data.size() == expected && in_grad.size() == expected);
-//     CHECK_EQ(req.size(), expected);
-//     CHECK_EQ(in_data[rnn_enum::kWeight].CheckContiguous(), true);
-//     // get data
-//     Stream<xpu> *s = ctx.get_stream<xpu>();
-//     Tensor<xpu, 4, DType> data = in_data[rnn_enum::kData].get<xpu, 4, DType>(s);
-//     Tensor<xpu, 4, DType> grad = out_grad[rnn_enum::kOut].get<xpu, 4, DType>(s);
-//     Tensor<xpu, 4, DType> gdata = in_grad[rnn_enum::kData].get<xpu, 4, DType>(s);
-//     Shape<3> wmat_shape =
-//         Shape3(param_.num_group,
-//                data.shape_[1] / param_.num_group,
-//                param_.num_filter / param_.num_group * param_.kernel[0] * param_.kernel[1]);
-//     Tensor<xpu, 3, DType> wmat =
-//         in_data[rnn_enum::kWeight].get_with_shape<xpu, 3, DType>(wmat_shape, s);
-//     Tensor<xpu, 3, DType> gwmat =
-//         in_grad[rnn_enum::kWeight].get_with_shape<xpu, 3, DType>(wmat_shape, s);
-// #if defined(__CUDACC__)
-//     CHECK_EQ(s->blas_handle_ownership_, Stream<xpu>::OwnHandle)
-//         << "Must init CuBLAS handle in stream";
-// #endif
-//     const index_t nbatch = data.size(0);
-//     Tensor<xpu, 1, DType> workspace =
-//         ctx.requested[rnn_enum::kTempSpace].get_space_typed<xpu, 1, DType>(
-//             Shape1(this->InitTemp(grad.shape_, data.shape_)), s);
-//     for (index_t i = 0; i < nbatch; i += nstep_) {
-//       const index_t step = std::min(nstep_, nbatch - i);
-//       Tensor<xpu, 2, DType> temp_col = Tensor<xpu, 2, DType>(
-//                                            workspace.dptr_,
-//                                            Shape2(shape_colunit_[0],
-//                                            shape_colunit_[1] * step), s);
-//       Tensor<xpu, 3, DType> temp_dst = Tensor<xpu, 3, DType>(
-//                                            workspace.dptr_ + temp_col.shape_.Size(),
-//                                            Shape3(shape_dstunit_[0],
-//                                            shape_dstunit_[1],
-//                                            shape_dstunit_[2] * step), s);
-//       temp_dst = reshape(swapaxis<1, 0>(data.Slice(i, i + step)), temp_dst.shape_);
-//       if (param_.pad[0] == 0 && param_.pad[1] == 0) {
-//         temp_col = unpack_patch2col(grad.Slice(i, i + step),
-//                                      param_.kernel[0],
-//                                      param_.kernel[1],
-//                                      param_.stride[0],
-//                                      param_.stride[1],
-//                                      1, 1);  // RNN only support dilate equals 1
-//       } else {
-//         temp_col = unpack_patch2col(pad(grad.Slice(i, i + step), param_.pad[0], param_.pad[1]),
-//                                      param_.kernel[0],
-//                                      param_.kernel[1],
-//                                      param_.stride[0],
-//                                      param_.stride[1],
-//                                      1, 1);  // RNN only support dilate equals 1
-//       }
-//       const index_t gstride = temp_col.size(0) / param_.num_group;
-//       for (uint32_t gid = 0; gid < param_.num_group; ++gid) {
-//         Tensor<xpu, 2, DType> tmpc = temp_col.Slice(gstride * gid, gstride * (gid + 1));
-//         if (i == 0) {
-//           Tensor<xpu, 2, DType> tmp_gwmat = gwmat[gid];
-//           Assign(tmp_gwmat, req[rnn_enum::kWeight], dot(temp_dst[gid], tmpc.T()));
-//         } else {
-//           gwmat[gid] += dot(temp_dst[gid], tmpc.T());
-//         }
-//       }
-//       if (req[rnn_enum::kData] == kWriteTo || req[rnn_enum::kData] == kWriteInplace) {
-//         for (uint32_t gid = 0; gid < param_.num_group; ++gid) {
-//           Tensor<xpu, 2, DType> tmpc = temp_col.Slice(gstride * gid, gstride * (gid + 1));
-//           temp_dst[gid] = dot(wmat[gid], tmpc);
-//         }
-//         gdata.Slice(i, i + step) = swapaxis<1, 0>(reshape(temp_dst,
-//                                                     mshadow::Shape4(gdata.shape_[1],
-//                                                     step,
-//                                                     gdata.size(2),
-//                                                     gdata.size(3))));
-//       }
-//     }
-//     if (!param_.no_bias) {
-//       Tensor<xpu, 1, DType> gbias = in_grad[rnn_enum::kBias].get<xpu, 1, DType>(s);
-//       Assign(gbias, req[rnn_enum::kBias], sumall_except_dim<1>(grad));
-//     }
+    // TODO: add MShadow implementation
   }
-
- private:
-//   inline index_t InitTemp(const mshadow::Shape<4> &ishape,
-//                           const mshadow::Shape<4> &oshape) {
-//     const int ksize_y = param_.kernel[0];
-//     const int ksize_x = param_.kernel[1];
-//     shape_colunit_ = mshadow::Shape2(ishape[1] * ksize_y * ksize_x,
-//                                      oshape[2] * oshape[3]);
-//     shape_dstunit_ = mshadow::Shape3(param_.num_group,
-//                                      oshape[1] / param_.num_group,
-//                                      oshape[2] * oshape[3]);
-//     // See convolution for workspace calculations
-//     nstep_ = std::max(
-//         std::min(
-//             static_cast<index_t>(
-//                 param_.workspace / (shape_colunit_.Size() + shape_dstunit_.Size())),
-//             ishape[0]),
-//         1U);
-
-//     mshadow::Shape<2> scol = mshadow::Shape2(shape_colunit_[0],
-//                                              shape_colunit_[1] * nstep_);
-//     mshadow::Shape<3> sdst = mshadow::Shape3(shape_dstunit_[0],
-//                                              shape_dstunit_[1],
-//                                              shape_dstunit_[2] * nstep_);
-//     index_t required_size = scol.Size() + sdst.Size();
-//     CHECK_GE(param_.workspace, required_size)
-//       << "\nMinimum workspace size: " << required_size * sizeof(DType) << " Bytes\n"
-//       << "Given: " << param_.workspace * sizeof(DType);
-//     return required_size;
-//   }
 
  private:
   RNNParam param_;
 };  // class RNNOp
-
-
-
 
 template<typename xpu>
 Operator* CreateOp(RNNParam param, int dtype);
@@ -337,6 +145,14 @@ class RNNProp : public OperatorProperty {
       return {"data", "weight", "state", "cell_state"};
     } else {
       return {"data", "weight", "state"};
+    }
+  }
+
+  std::vector<std::string> ListOutputs() const override {
+    if (param_.mode == rnn_enum::kLstm) {
+      return {"output", "final_state", "final_state_cell"};
+    } else {
+      return {"output", "final_state"};
     }
   }
 
@@ -386,7 +202,7 @@ class RNNProp : public OperatorProperty {
     SHAPE_ASSIGN_CHECK(*in_shape, rnn_enum::kWeight, Shape1(weight_size));
     // infer output size
     TShape oshape = dshape;
-    oshape[3] = numDirections * param_.state_size;
+    oshape[2] = numDirections * param_.state_size;
     // infer output state size   
     TShape outStateShape = dshape;
     outStateShape[0] = total_layers;
@@ -396,6 +212,7 @@ class RNNProp : public OperatorProperty {
     out_shape->clear();   
     out_shape->push_back(oshape);
     out_shape->push_back(outStateShape);
+    // Deal with lstm cell state
     if (param_.mode == rnn_enum::kLstm) 
       out_shape->push_back(outStateShape);
     return true;

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -1,0 +1,471 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file rnn-inl.h
+ * \brief
+ * \author Sebastian Bodenstein
+*/
+#ifndef MXNET_OPERATOR_RNN_INL_H_
+#define MXNET_OPERATOR_RNN_INL_H_
+
+#include <dmlc/logging.h>
+#include <dmlc/parameter.h>
+#include <mxnet/operator.h>
+#include <algorithm>
+#include <map>
+#include <vector>
+#include <string>
+#include <utility>
+#include "./operator_common.h"
+
+namespace mxnet {
+namespace op {
+
+namespace rnn_enum {
+  enum RNNOpInputs {kData, kWeight, kStateIn, kCellStateIn};
+  enum RNNOpOutputs {kOut, kStateOut, kCellStateOut};
+  enum RNNModeType {kRnnRelu, kRnnTanh, kLstm, kGru};  
+  enum RNNDirectionType {kUnidirectional, kBidirectional};
+  enum RNNOpResource {kTempSpace};
+}
+
+// A utility function to calculate input size
+
+inline int rnn_single_param_size(int inputSize,
+                                int hiddenSize, 
+                                int mode){
+  int size = hiddenSize * (hiddenSize + inputSize + 2);
+  // Different RNN's have different num weights
+  switch(mode)
+  {
+    case rnn_enum::kRnnRelu:
+      size *= 1 ;
+      break;
+    case rnn_enum::kRnnTanh:
+      size *= 1;
+      break;
+    case rnn_enum::kLstm:
+      size *= 4;
+      break;
+    case rnn_enum::kGru:
+      size *= 3;
+      break;
+  }
+  return size;
+}
+
+inline int rnn_param_size(int layerNum, 
+                          int inputSize,
+                          int hiddenSize, 
+                          int direction, 
+                          int mode){
+  // get size of first layer
+  int size = rnn_single_param_size(inputSize, hiddenSize, mode);
+  // get size of remaining layers
+  if(direction == rnn_enum::kUnidirectional)
+    size += (layerNum - 1) * rnn_single_param_size(hiddenSize, hiddenSize, mode);
+  else // bidirectional case: input size increases by 2
+    size += (layerNum - 1) * rnn_single_param_size(2 * hiddenSize, hiddenSize, mode);
+  return size;
+}
+
+struct RNNParam : public dmlc::Parameter<RNNParam> {
+  uint32_t state_size;
+  uint32_t num_layers;
+  uint64_t workspace;
+  bool batch_first;
+  int direction;
+  int mode;
+
+  DMLC_DECLARE_PARAMETER(RNNParam) {
+    DMLC_DECLARE_FIELD(state_size)
+    .describe("size of the state for each layer");
+
+    DMLC_DECLARE_FIELD(num_layers)
+    .describe("number of stacked layers");
+
+    DMLC_DECLARE_FIELD(workspace).set_default(512).set_range(0, 8192)
+    .describe("Tmp workspace for RNN (MB)");
+
+    DMLC_DECLARE_FIELD(direction)
+    .add_enum("unidirectional", rnn_enum::kUnidirectional)
+    .add_enum("bidirectional", rnn_enum::kBidirectional)
+    .describe("specifies the recurrence pattern");
+
+    DMLC_DECLARE_FIELD(mode)
+    .add_enum("rnn_relu", rnn_enum::kRnnRelu)
+    .add_enum("rnn_tanh", rnn_enum::kRnnTanh)
+    .add_enum("lstm", rnn_enum::kLstm)
+    .add_enum("gru", rnn_enum::kGru)
+    .describe("the type of RNN to compute");
+  }
+};
+
+template<typename xpu, typename DType>
+class RNNOp : public Operator {
+ public:
+  explicit RNNOp(RNNParam p) {
+    this->param_ = p;
+    // convert MBytes first to Bytes and then to elements.
+    param_.workspace = (param_.workspace << 20) / sizeof(real_t);
+  }
+
+  virtual void Forward(const OpContext &ctx,
+                       const std::vector<TBlob> &in_data,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &out_data,
+                       const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+//     CHECK_EQ(req[rnn_enum::kOut], kWriteTo);
+  
+//     CHECK_EQ(in_data.size(), expected);
+//     CHECK_EQ(out_data.size(), 1);
+//     Stream<xpu> *s = ctx.get_stream<xpu>();
+//     Tensor<xpu, 4, DType> data = in_data[rnn_enum::kData].get<xpu, 4, DType>(s);
+//     Tensor<xpu, 4, DType> out = out_data[rnn_enum::kOut].get<xpu, 4, DType>(s);
+//     Shape<3> wmat_shape =
+//         Shape3(param_.num_group,
+//                data.shape_[1] / param_.num_group,
+//                param_.num_filter / param_.num_group * param_.kernel[0] * param_.kernel[1]);
+//     Tensor<xpu, 3, DType> wmat =
+//         in_data[rnn_enum::kWeight].get_with_shape<xpu, 3, DType>(wmat_shape, s);
+// #if defined(__CUDACC__)
+//     CHECK_EQ(s->blas_handle_ownership_, Stream<xpu>::OwnHandle)
+//         << "Must init CuBLAS handle in stream";
+// #endif
+//     const index_t nbatch = data.size(0);
+//     Tensor<xpu, 1, DType> workspace =
+//         ctx.requested[rnn_enum::kTempSpace].get_space_typed<xpu, 1, DType>(
+//             Shape1(this->InitTemp(out.shape_, data.shape_)), s);
+//     for (index_t i = 0; i < nbatch; i += nstep_) {
+//       const index_t step = std::min(nstep_, nbatch - i);
+//       Tensor<xpu, 2, DType> temp_col = Tensor<xpu, 2, DType>(
+//                                             workspace.dptr_,
+//                                             Shape2(shape_colunit_[0],
+//                                             shape_colunit_[1] * step), s);
+//       Tensor<xpu, 3, DType> temp_dst = Tensor<xpu, 3, DType>(
+//                                            workspace.dptr_ + temp_col.shape_.Size(),
+//                                            Shape3(shape_dstunit_[0],
+//                                            shape_dstunit_[1],
+//                                            shape_dstunit_[2] * step), s);
+//       temp_dst = reshape(swapaxis<1, 0>(data.Slice(i, i + step)), temp_dst.shape_);
+//       if (param_.pad[0] == 0 && param_.pad[1] == 0) {
+//         temp_col = unpack_patch2col(out.Slice(i, i + step),
+//                                     param_.kernel[0],
+//                                     param_.kernel[1],
+//                                     param_.stride[0],
+//                                     param_.stride[1],
+//                                     1, 1);  // RNN only support dilate equals 1
+//       } else {
+//         temp_col = unpack_patch2col(pad(out.Slice(i, i + step),
+//                                         param_.pad[0], param_.pad[1]),
+//                                     param_.kernel[0],
+//                                     param_.kernel[1],
+//                                     param_.stride[0],
+//                                     param_.stride[1],
+//                                     1, 1);  // RNN only support dilate equals 1
+//       }
+//       const index_t gstride = temp_col.size(0) / param_.num_group;
+//       for (uint32_t gid = 0; gid < param_.num_group; ++gid) {
+//         mshadow::Tensor<xpu, 2, DType> tmpc = temp_col.Slice(gstride * gid,
+//                                               gstride * (gid + 1));
+//         tmpc = dot(wmat[gid].T(), temp_dst[gid]);
+//       }
+//       if (param_.pad[0] == 0 && param_.pad[1] == 0) {
+//         out.Slice(i, i + step) = pack_col2patch(temp_col,
+//                                    out.Slice(i, i + step).shape_,
+//                                    param_.kernel[0],
+//                                    param_.kernel[1],
+//                                    param_.stride[0],
+//                                    1);  // RNN only support dilate equals 1
+//       } else {
+//         Shape<4> pshape = out.Slice(i, i + step).shape_;
+//         pshape[2] += 2 * param_.pad[0];
+//         pshape[3] += 2 * param_.pad[1];
+//         out.Slice(i, i + step) = crop(pack_col2patch(temp_col,
+//                                         pshape,
+//                                         param_.kernel[0],
+//                                         param_.kernel[1],
+//                                         param_.stride[0],
+//                                         1),  // RNN only support dilate equals 1
+//                                         out[i][0].shape_);
+//       }
+//     }
+//     if (!param_.no_bias) {
+//       // add bias, broadcast bias to dim 1: channel
+//       Tensor<xpu, 1, DType> bias = in_data[rnn_enum::kBias].get<xpu, 1, DType>(s);
+//       out += broadcast<1>(bias, out.shape_);
+//     }
+  }
+
+  virtual void Backward(const OpContext &ctx,
+                        const std::vector<TBlob> &out_grad,
+                        const std::vector<TBlob> &in_data,
+                        const std::vector<TBlob> &out_data,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<TBlob> &in_grad,
+                        const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    // TODO(bing): check the BLAS Handle, be careful
+//     CHECK_EQ(out_grad.size(), 1);
+//     size_t expected = param_.no_bias == 0 ? 3 : 2;
+//     CHECK(in_data.size() == expected && in_grad.size() == expected);
+//     CHECK_EQ(req.size(), expected);
+//     CHECK_EQ(in_data[rnn_enum::kWeight].CheckContiguous(), true);
+//     // get data
+//     Stream<xpu> *s = ctx.get_stream<xpu>();
+//     Tensor<xpu, 4, DType> data = in_data[rnn_enum::kData].get<xpu, 4, DType>(s);
+//     Tensor<xpu, 4, DType> grad = out_grad[rnn_enum::kOut].get<xpu, 4, DType>(s);
+//     Tensor<xpu, 4, DType> gdata = in_grad[rnn_enum::kData].get<xpu, 4, DType>(s);
+//     Shape<3> wmat_shape =
+//         Shape3(param_.num_group,
+//                data.shape_[1] / param_.num_group,
+//                param_.num_filter / param_.num_group * param_.kernel[0] * param_.kernel[1]);
+//     Tensor<xpu, 3, DType> wmat =
+//         in_data[rnn_enum::kWeight].get_with_shape<xpu, 3, DType>(wmat_shape, s);
+//     Tensor<xpu, 3, DType> gwmat =
+//         in_grad[rnn_enum::kWeight].get_with_shape<xpu, 3, DType>(wmat_shape, s);
+// #if defined(__CUDACC__)
+//     CHECK_EQ(s->blas_handle_ownership_, Stream<xpu>::OwnHandle)
+//         << "Must init CuBLAS handle in stream";
+// #endif
+//     const index_t nbatch = data.size(0);
+//     Tensor<xpu, 1, DType> workspace =
+//         ctx.requested[rnn_enum::kTempSpace].get_space_typed<xpu, 1, DType>(
+//             Shape1(this->InitTemp(grad.shape_, data.shape_)), s);
+//     for (index_t i = 0; i < nbatch; i += nstep_) {
+//       const index_t step = std::min(nstep_, nbatch - i);
+//       Tensor<xpu, 2, DType> temp_col = Tensor<xpu, 2, DType>(
+//                                            workspace.dptr_,
+//                                            Shape2(shape_colunit_[0],
+//                                            shape_colunit_[1] * step), s);
+//       Tensor<xpu, 3, DType> temp_dst = Tensor<xpu, 3, DType>(
+//                                            workspace.dptr_ + temp_col.shape_.Size(),
+//                                            Shape3(shape_dstunit_[0],
+//                                            shape_dstunit_[1],
+//                                            shape_dstunit_[2] * step), s);
+//       temp_dst = reshape(swapaxis<1, 0>(data.Slice(i, i + step)), temp_dst.shape_);
+//       if (param_.pad[0] == 0 && param_.pad[1] == 0) {
+//         temp_col = unpack_patch2col(grad.Slice(i, i + step),
+//                                      param_.kernel[0],
+//                                      param_.kernel[1],
+//                                      param_.stride[0],
+//                                      param_.stride[1],
+//                                      1, 1);  // RNN only support dilate equals 1
+//       } else {
+//         temp_col = unpack_patch2col(pad(grad.Slice(i, i + step), param_.pad[0], param_.pad[1]),
+//                                      param_.kernel[0],
+//                                      param_.kernel[1],
+//                                      param_.stride[0],
+//                                      param_.stride[1],
+//                                      1, 1);  // RNN only support dilate equals 1
+//       }
+//       const index_t gstride = temp_col.size(0) / param_.num_group;
+//       for (uint32_t gid = 0; gid < param_.num_group; ++gid) {
+//         Tensor<xpu, 2, DType> tmpc = temp_col.Slice(gstride * gid, gstride * (gid + 1));
+//         if (i == 0) {
+//           Tensor<xpu, 2, DType> tmp_gwmat = gwmat[gid];
+//           Assign(tmp_gwmat, req[rnn_enum::kWeight], dot(temp_dst[gid], tmpc.T()));
+//         } else {
+//           gwmat[gid] += dot(temp_dst[gid], tmpc.T());
+//         }
+//       }
+//       if (req[rnn_enum::kData] == kWriteTo || req[rnn_enum::kData] == kWriteInplace) {
+//         for (uint32_t gid = 0; gid < param_.num_group; ++gid) {
+//           Tensor<xpu, 2, DType> tmpc = temp_col.Slice(gstride * gid, gstride * (gid + 1));
+//           temp_dst[gid] = dot(wmat[gid], tmpc);
+//         }
+//         gdata.Slice(i, i + step) = swapaxis<1, 0>(reshape(temp_dst,
+//                                                     mshadow::Shape4(gdata.shape_[1],
+//                                                     step,
+//                                                     gdata.size(2),
+//                                                     gdata.size(3))));
+//       }
+//     }
+//     if (!param_.no_bias) {
+//       Tensor<xpu, 1, DType> gbias = in_grad[rnn_enum::kBias].get<xpu, 1, DType>(s);
+//       Assign(gbias, req[rnn_enum::kBias], sumall_except_dim<1>(grad));
+//     }
+  }
+
+ private:
+//   inline index_t InitTemp(const mshadow::Shape<4> &ishape,
+//                           const mshadow::Shape<4> &oshape) {
+//     const int ksize_y = param_.kernel[0];
+//     const int ksize_x = param_.kernel[1];
+//     shape_colunit_ = mshadow::Shape2(ishape[1] * ksize_y * ksize_x,
+//                                      oshape[2] * oshape[3]);
+//     shape_dstunit_ = mshadow::Shape3(param_.num_group,
+//                                      oshape[1] / param_.num_group,
+//                                      oshape[2] * oshape[3]);
+//     // See convolution for workspace calculations
+//     nstep_ = std::max(
+//         std::min(
+//             static_cast<index_t>(
+//                 param_.workspace / (shape_colunit_.Size() + shape_dstunit_.Size())),
+//             ishape[0]),
+//         1U);
+
+//     mshadow::Shape<2> scol = mshadow::Shape2(shape_colunit_[0],
+//                                              shape_colunit_[1] * nstep_);
+//     mshadow::Shape<3> sdst = mshadow::Shape3(shape_dstunit_[0],
+//                                              shape_dstunit_[1],
+//                                              shape_dstunit_[2] * nstep_);
+//     index_t required_size = scol.Size() + sdst.Size();
+//     CHECK_GE(param_.workspace, required_size)
+//       << "\nMinimum workspace size: " << required_size * sizeof(DType) << " Bytes\n"
+//       << "Given: " << param_.workspace * sizeof(DType);
+//     return required_size;
+//   }
+
+ private:
+  RNNParam param_;
+};  // class RNNOp
+
+
+
+
+template<typename xpu>
+Operator* CreateOp(RNNParam param, int dtype);
+
+#if DMLC_USE_CXX11
+class RNNProp : public OperatorProperty {
+ public:
+  std::vector<std::string> ListArguments() const override {
+    if (param_.mode == rnn_enum::kLstm) {
+      return {"data", "weight", "state", "cell_state"};
+    } else {
+      return {"data", "weight", "state"};
+    }
+  }
+
+  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
+    param_.Init(kwargs);
+  }
+
+  std::map<std::string, std::string> GetParams() const override {
+    return param_.__DICT__();
+  }
+
+  bool InferShape(std::vector<TShape> *in_shape,
+                  std::vector<TShape> *out_shape,
+                  std::vector<TShape> *aux_shape) const override {
+    using namespace mshadow;
+    if (param_.mode == rnn_enum::kLstm) {
+      CHECK_EQ(in_shape->size(), 4) << "Input:[data, weight, state, cell_state]";
+    } else {
+      CHECK_EQ(in_shape->size(), 3) << "Input:[data, weight, state]";
+    }
+    const TShape &dshape = (*in_shape)[rnn_enum::kData];
+    if (dshape.ndim() ==  0) return false;
+    CHECK_EQ(dshape.ndim(), 3) \
+        << "Input data should be rank-3 tensor of dim (seqLength, batch, inputDim).";
+    // Infer hidden state + cell state
+    int batchSize = dshape[0];
+    int inputSize = dshape[2];
+    int numDirections = 1;
+    if(param_.direction == rnn_enum::kBidirectional){
+      numDirections = 2;
+    }
+    int total_layers = numDirections * param_.num_layers; // double for bidirectional
+    SHAPE_ASSIGN_CHECK(*in_shape,
+                       rnn_enum::kStateIn,
+                       Shape3(total_layers, batchSize, param_.state_size));
+    if (param_.mode == rnn_enum::kLstm){
+      SHAPE_ASSIGN_CHECK(*in_shape,
+                        rnn_enum::kCellStateIn,
+                        Shape3(total_layers, batchSize, param_.state_size));
+    }
+    // infer weight size
+    int weight_size = rnn_param_size(param_.num_layers, 
+                                    inputSize, 
+                                    param_.state_size, 
+                                    param_.direction, 
+                                    param_.mode);
+    SHAPE_ASSIGN_CHECK(*in_shape, rnn_enum::kWeight, Shape1(weight_size));
+    // infer output size
+    TShape oshape = dshape;
+    oshape[3] = numDirections * param_.state_size;
+    // infer output state size   
+    TShape outStateShape = dshape;
+    outStateShape[0] = total_layers;
+    outStateShape[1] = batchSize;
+    outStateShape[2] = param_.state_size;
+
+    out_shape->clear();   
+    out_shape->push_back(oshape);
+    out_shape->push_back(outStateShape);
+    if (param_.mode == rnn_enum::kLstm) 
+      out_shape->push_back(outStateShape);
+    return true;
+  }
+
+  bool InferType(std::vector<int> *in_type,
+                 std::vector<int> *out_type,
+                 std::vector<int> *aux_type) const override {
+    CHECK_GE(in_type->size(), 1);
+    int dtype = (*in_type)[0];
+    CHECK_NE(dtype, -1) << "First input must have specified type";
+    for (index_t i = 0; i < in_type->size(); ++i) {
+      if ((*in_type)[i] == -1) {
+        (*in_type)[i] = dtype;
+      } else {
+        CHECK_EQ((*in_type)[i], dtype) << "This layer requires uniform type. "
+                                       << "Expected " << dtype << " v.s. given "
+                                       << (*in_type)[i] << " at " << ListArguments()[i];
+      }
+    }
+    out_type->clear();
+    out_type->push_back(dtype);
+    out_type->push_back(dtype);
+    if (param_.mode == rnn_enum::kLstm) 
+      out_type->push_back(dtype);
+    return true;
+  }
+
+  OperatorProperty* Copy() const override {
+    auto ptr = new RNNProp();
+    ptr->param_ = param_;
+    return ptr;
+  }
+
+  std::string TypeString() const override {
+    return "RNN";
+  }
+
+  std::vector<int> DeclareBackwardDependency(
+    const std::vector<int> &out_grad,
+    const std::vector<int> &in_data,
+    const std::vector<int> &out_data) const override {
+    if (param_.mode == rnn_enum::kLstm)
+      return {out_grad[rnn_enum::kOut], in_data[rnn_enum::kData], in_data[rnn_enum::kWeight]};
+    else
+      return {out_grad[rnn_enum::kOut], in_data[rnn_enum::kData], in_data[rnn_enum::kWeight]};
+  }
+
+  std::vector<ResourceRequest> ForwardResource(
+      const std::vector<TShape> &in_shape) const override {
+    return {ResourceRequest::kTempSpace};
+  }
+
+  std::vector<ResourceRequest> BackwardResource(
+      const std::vector<TShape> &in_shape) const override {
+    return {ResourceRequest::kTempSpace};
+  }
+
+  Operator* CreateOperator(Context ctx) const override {
+    LOG(FATAL) << "Not Implemented";
+    return NULL;
+  }
+
+  Operator* CreateOperatorEx(Context ctx, std::vector<TShape> *in_shape,
+                             std::vector<int> *in_type) const override;
+
+ private:
+  RNNParam param_;
+};  // class RNNProp
+#endif  // DMLC_USE_CXX11
+}  // namespace op
+}  // namespace mxnet
+#endif  // MXNET_OPERATOR_RNN_INL_H_

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -274,7 +274,7 @@ class RNNProp : public OperatorProperty {
 
     if (param_.mode == rnn_enum::kLstm) {
       dep.push_back(in_data[rnn_enum::kStateCell]);
-      if(param_.state_outputs) {
+      if (param_.state_outputs) {
         dep.push_back(out_data[rnn_enum::kStateCellOut]);
         dep.push_back(out_grad[rnn_enum::kStateCellOut]);
       }

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -59,8 +59,10 @@ inline int rnn_param_size(int layerNum,
   // get size of first layer
   int size = rnn_single_param_size(inputSize, hiddenSize, mode);
   // get size of remaining layers
-  if(bidirectional)
+  if(bidirectional){
     size += (layerNum - 1) * rnn_single_param_size(2 * hiddenSize, hiddenSize, mode);
+    size *= 2;
+  }
   else 
     size += (layerNum - 1) * rnn_single_param_size(hiddenSize, hiddenSize, mode);  
   return size;
@@ -102,12 +104,6 @@ template<typename xpu, typename DType>
 class RNNOp : public Operator {
  public:
   explicit RNNOp(RNNParam p) {
-    // convert MBytes first to Bytes and then to elements.
-    param_.pkeep_ = 1.0f - param_.p;
-    if(param_.mode == rnn_enum::kLstm)
-      param_.lstm_q_ = true;
-    else
-      param_.lstm_q_ = false;
   }
 
   virtual void Forward(const OpContext &ctx,

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -30,13 +30,12 @@ namespace rnn_enum {
 // A utility function to calculate input size
 inline int rnn_single_param_size(int inputSize,
                                 int hiddenSize,
-                                int mode){
+                                int mode) {
   int size = hiddenSize * (hiddenSize + inputSize + 2);
   // Different RNN's have different num weights
-  switch(mode)
-  {
+  switch (mode) {
     case rnn_enum::kRnnRelu:
-      size *= 1 ;
+      size *= 1;
       break;
     case rnn_enum::kRnnTanh:
       size *= 1;
@@ -55,16 +54,16 @@ inline int rnn_param_size(int layerNum,
                           int inputSize,
                           int hiddenSize,
                           bool bidirectional,
-                          int mode){
+                          int mode) {
   // get size of first layer
   int size = rnn_single_param_size(inputSize, hiddenSize, mode);
   // get size of remaining layers
-  if(bidirectional){
+  if (bidirectional) {
     size += (layerNum - 1) * rnn_single_param_size(2 * hiddenSize, hiddenSize, mode);
     size *= 2;
+  } else {
+    size += (layerNum - 1) * rnn_single_param_size(hiddenSize, hiddenSize, mode);
   }
-  else 
-    size += (layerNum - 1) * rnn_single_param_size(hiddenSize, hiddenSize, mode);  
   return size;
 }
 
@@ -75,7 +74,7 @@ struct RNNParam : public dmlc::Parameter<RNNParam> {
   int mode;
   float p, pkeep_;
   int seq_length_, batch_size_, input_size_;
-  bool lstm_q_; // whether type is lstm 
+  bool lstm_q_;  // whether type is lstm
 
   DMLC_DECLARE_PARAMETER(RNNParam) {
     DMLC_DECLARE_FIELD(state_size)
@@ -93,14 +92,13 @@ struct RNNParam : public dmlc::Parameter<RNNParam> {
     .add_enum("lstm", rnn_enum::kLstm)
     .add_enum("gru", rnn_enum::kGru)
     .describe("the type of RNN to compute");
-    
+
     DMLC_DECLARE_FIELD(p).set_default(0.)
     .set_range(0, 1)
     .describe("Fraction of the input that gets dropped out at training time");
 
     DMLC_DECLARE_FIELD(state_outputs).set_default(false)
     .describe("Whether to have the states as symbol outputs.");
-
   }
 };
 
@@ -117,7 +115,7 @@ class RNNOp : public Operator {
                        const std::vector<TBlob> &aux_args) {
     using namespace mshadow;
     using namespace mshadow::expr;
-    // TODO: add MShadow implementation
+    // TODO(sbodenstein): add MShadow implementation
   }
 
   virtual void Backward(const OpContext &ctx,
@@ -129,7 +127,7 @@ class RNNOp : public Operator {
                         const std::vector<TBlob> &aux_args) {
     using namespace mshadow;
     using namespace mshadow::expr;
-    // TODO: add MShadow implementation
+    // TODO(sbodenstein): add MShadow implementation
   }
 
  private:
@@ -153,14 +151,14 @@ class RNNProp : public OperatorProperty {
   std::vector<std::string> ListOutputs() const override {
     if (param_.mode == rnn_enum::kLstm)
       return {"output", "state", "state_cell"};
-    else 
+    else
       return {"output", "state"};
   }
 
   int NumOutputs() const override {
     if (param_.mode == rnn_enum::kLstm)
       return 3;
-    else 
+    else
       return 2;
   }
 
@@ -195,7 +193,7 @@ class RNNProp : public OperatorProperty {
     int batch_size = dshape[1];
     int input_size = dshape[2];
     int numDirections = param_.bidirectional ? 2 : 1;
-    int total_layers = numDirections * param_.num_layers; // double for bidirectional
+    int total_layers = numDirections * param_.num_layers;  // double for bidirectional
     SHAPE_ASSIGN_CHECK(*in_shape,
                        rnn_enum::kState,
                        Shape3(total_layers, batch_size, param_.state_size));
@@ -223,7 +221,7 @@ class RNNProp : public OperatorProperty {
     out_shape->push_back(oshape);
     out_shape->push_back(outStateShape);
     // Deal with lstm cell state
-    if(param_.mode == rnn_enum::kLstm)
+    if (param_.mode == rnn_enum::kLstm)
       out_shape->push_back(outStateShape);
     return true;
   }

--- a/src/operator/rnn.cc
+++ b/src/operator/rnn.cc
@@ -19,8 +19,9 @@ Operator *CreateOp<cpu>(RNNParam param, int dtype) {
   return op;
 }
 
-Operator *RNNProp::CreateOperatorEx(Context ctx, std::vector<TShape> *in_shape,
-                                     std::vector<int> *in_type) const {                                 
+Operator *RNNProp::CreateOperatorEx(Context ctx,
+                                  std::vector<TShape> *in_shape,
+                                  std::vector<int> *in_type) const {
   std::vector<TShape> out_shape, aux_shape;
   std::vector<int> out_type, aux_type;
   CHECK(InferType(in_type, &out_type, &aux_type));

--- a/src/operator/rnn.cc
+++ b/src/operator/rnn.cc
@@ -20,7 +20,7 @@ Operator *CreateOp<cpu>(RNNParam param, int dtype) {
 }
 
 Operator *RNNProp::CreateOperatorEx(Context ctx, std::vector<TShape> *in_shape,
-                                     std::vector<int> *in_type) const {
+                                     std::vector<int> *in_type) const {                                 
   std::vector<TShape> out_shape, aux_shape;
   std::vector<int> out_type, aux_type;
   CHECK(InferType(in_type, &out_type, &aux_type));
@@ -34,7 +34,7 @@ MXNET_REGISTER_OP_PROPERTY(RNN, RNNProp)
 .describe("Apply a recurrent layer to input.")
 .add_argument("data", "Symbol", "Input data to RNN")
 .add_argument("parameters", "Symbol", "Vector of all RNN trainable parameters")
-.add_argument("hidden_state", "Symbol", "initial hidden state of the RNN")
+.add_argument("state", "Symbol", "initial hidden state of the RNN")
 .add_argument("cell_state", "Symbol", "initial cell state for LSTM networks (only for LSTM)")
 .add_arguments(RNNParam::__FIELDS__());
 }  // namespace op

--- a/src/operator/rnn.cc
+++ b/src/operator/rnn.cc
@@ -33,9 +33,9 @@ DMLC_REGISTER_PARAMETER(RNNParam);
 MXNET_REGISTER_OP_PROPERTY(RNN, RNNProp)
 .describe("Apply a recurrent layer to input.")
 .add_argument("data", "Symbol", "Input data to RNN")
-.add_argument("weight", "Symbol", "Weight for RNN layers")
+.add_argument("parameters", "Symbol", "Vector of all RNN trainable parameters")
 .add_argument("hidden_state", "Symbol", "initial hidden state of the RNN")
-.add_argument("cell_state", "Symbol", "initial cell state for LSTM networks")
-.add_arguments(RNNParam::__FIELDS__()); 
+.add_argument("cell_state", "Symbol", "initial cell state for LSTM networks (only for LSTM)")
+.add_arguments(RNNParam::__FIELDS__());
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/rnn.cc
+++ b/src/operator/rnn.cc
@@ -35,7 +35,7 @@ MXNET_REGISTER_OP_PROPERTY(RNN, RNNProp)
 .add_argument("data", "Symbol", "Input data to RNN")
 .add_argument("parameters", "Symbol", "Vector of all RNN trainable parameters")
 .add_argument("state", "Symbol", "initial hidden state of the RNN")
-.add_argument("cell_state", "Symbol", "initial cell state for LSTM networks (only for LSTM)")
+.add_argument("state_cell", "Symbol", "initial cell state for LSTM networks (only for LSTM)")
 .add_arguments(RNNParam::__FIELDS__());
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/rnn.cc
+++ b/src/operator/rnn.cc
@@ -1,0 +1,41 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file rnn.cc
+ * \brief
+ * \author Sebastian Bodenstein
+*/
+
+#include "./rnn-inl.h"
+
+namespace mxnet {
+namespace op {
+template<>
+Operator *CreateOp<cpu>(RNNParam param, int dtype) {
+  LOG(FATAL) << "RNN is only available for gpu at the moment.";
+  Operator *op = NULL;
+  MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
+    op = new RNNOp<cpu, DType>(param);
+  });
+  return op;
+}
+
+Operator *RNNProp::CreateOperatorEx(Context ctx, std::vector<TShape> *in_shape,
+                                     std::vector<int> *in_type) const {
+  std::vector<TShape> out_shape, aux_shape;
+  std::vector<int> out_type, aux_type;
+  CHECK(InferType(in_type, &out_type, &aux_type));
+  CHECK(InferShape(in_shape, &out_shape, &aux_shape));
+  DO_BIND_DISPATCH(CreateOp, param_, (*in_type)[0]);
+}
+
+DMLC_REGISTER_PARAMETER(RNNParam);
+
+MXNET_REGISTER_OP_PROPERTY(RNN, RNNProp)
+.describe("Apply a recurrent layer to input.")
+.add_argument("data", "Symbol", "Input data to RNN")
+.add_argument("weight", "Symbol", "Weight for RNN layers")
+.add_argument("hidden_state", "Symbol", "initial hidden state of the RNN")
+.add_argument("cell_state", "Symbol", "initial cell state for LSTM networks")
+.add_arguments(RNNParam::__FIELDS__()); 
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/rnn.cu
+++ b/src/operator/rnn.cu
@@ -1,0 +1,33 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file rnn.cu
+ * \brief
+ * \author Sebastian Bodenstein
+*/
+
+#include "./rnn-inl.h"
+#include <algorithm>
+#if MXNET_USE_CUDNN == 1 && CUDNN_MAJOR == 5
+#include "./cudnn_rnn-inl.h"
+#endif  // MXNET_USE_CUDNN && CUDNN_MAJOR
+
+namespace mxnet {
+namespace op {
+template<>
+Operator* CreateOp<gpu>(RNNParam param, int dtype) {
+  Operator *op = NULL;
+#if MXNET_USE_CUDNN == 1 && CUDNN_MAJOR == 5
+  MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
+    op = new CuDNNRNNOp<DType>(param);
+  })
+#else
+	1;
+  MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
+  op = new SpatialTransformerOp<gpu, DType>(param);
+  })
+#endif  // MXNET_USE_CUDNN && CUDNN_MAJOR
+  return op;
+}
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/rnn.cu
+++ b/src/operator/rnn.cu
@@ -21,10 +21,7 @@ Operator* CreateOp<gpu>(RNNParam param, int dtype) {
     op = new CuDNNRNNOp<DType>(param);
   })
 #else
-	1;
-  MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
-  op = new SpatialTransformerOp<gpu, DType>(param);
-  })
+   LOG(FATAL) << "RNN is only available for cuDNN at the moment.";
 #endif  // MXNET_USE_CUDNN && CUDNN_MAJOR
   return op;
 }

--- a/src/operator/rnn.cu
+++ b/src/operator/rnn.cu
@@ -21,7 +21,7 @@ Operator* CreateOp<gpu>(RNNParam param, int dtype) {
     op = new CuDNNRNNOp<DType>(param);
   })
 #else
-   LOG(FATAL) << "RNN is only available for cuDNN at the moment.";
+  LOG(FATAL) << "RNN is only available for cuDNN at the moment.";
 #endif  // MXNET_USE_CUDNN && CUDNN_MAJOR
   return op;
 }


### PR DESCRIPTION
This adds an interface to the cuDNN RNN operator. Some issues:

1. The forward pass in inference mode reproduces https://github.com/soumith/cudnn.torch
2. The backward mode is currently not working, due to incorrect handling of dropout descriptor. Correct handling of the dropout state needs to be added. 
3. It doesn't currently inherit the MXNet seed for dropout. How is this seed accessed?
4. This symbol currently only supports data in form [seq length, batch, input size], which is the native cuDNN format. Should add support for [batch, seq, input] as well, but will probably require a temp state + transpose. 
5. Gives an option to return multiple outputs (output + 2 states for LSTM, 1 for others). By default only a single output is returned, but sometimes you require access to the output states (eg generating text).
6. Currently only support the CUDNN_LINEAR_INPUT option for cudnnRNNInputMode_t.
7. Uses a single parameter vector. It will be useful to have a Python script to convert this to a dictionary of NDArray's giving each weight + bias for each layer.

See also: #2401